### PR TITLE
Add `refreshClan` endpoint and optimize update logic

### DIFF
--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -5,10 +5,8 @@
   </component>
   <component name="ChangeListManager">
     <list default="true" id="08130c95-e40a-4eff-916b-05872f0b417d" name="Changes" comment="WIP - Add battle log endpoint and logic, update models, and clean up related files">
-      <change afterPath="$PROJECT_DIR$/response_1762487055417.json" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/test.py" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/.gitignore" beforeDir="false" afterPath="$PROJECT_DIR$/.gitignore" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/clashstats/urls.py" beforeDir="false" afterPath="$PROJECT_DIR$/clashstats/urls.py" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/clashstats/views.py" beforeDir="false" afterPath="$PROJECT_DIR$/clashstats/views.py" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
@@ -34,22 +32,26 @@
       </map>
     </option>
     <option name="RECENT_GIT_ROOT_PATH" value="$PROJECT_DIR$" />
+    <option name="UPDATE_TYPE" value="REBASE" />
   </component>
-  <component name="GitHubPullRequestSearchHistory"><![CDATA[{
-  "lastFilter": {
-    "state": "OPEN",
-    "assignee": "edbourque0"
+  <component name="GitHubPullRequestSearchHistory">{
+  &quot;lastFilter&quot;: {
+    &quot;state&quot;: &quot;OPEN&quot;,
+    &quot;assignee&quot;: &quot;edbourque0&quot;
   }
-}]]></component>
-  <component name="GithubPullRequestsUISettings"><![CDATA[{
-  "selectedUrlAndAccountId": {
-    "url": "https://github.com/edbourque0/clashstats_v2.git",
-    "accountId": "5803b673-7161-4c75-aab1-8fe1e0037f35"
+}</component>
+  <component name="GithubPullRequestsUISettings">{
+  &quot;selectedUrlAndAccountId&quot;: {
+    &quot;url&quot;: &quot;https://github.com/edbourque0/clashstats_v2.git&quot;,
+    &quot;accountId&quot;: &quot;5803b673-7161-4c75-aab1-8fe1e0037f35&quot;
   }
+}</component>
+  <component name="HttpClientOnboardingState"><![CDATA[{
+  "isOnboardingCommentShown": true
 }]]></component>
-  <component name="ProjectColorInfo"><![CDATA[{
-  "associatedIndex": 7
-}]]></component>
+  <component name="ProjectColorInfo">{
+  &quot;associatedIndex&quot;: 7
+}</component>
   <component name="ProjectId" id="357gropTYOVDtYrMXe6J6XfgVZy" />
   <component name="ProjectLevelVcsManager">
     <ConfirmationsSetting value="2" id="Add" />
@@ -75,8 +77,9 @@
     "SHARE_PROJECT_CONFIGURATION_FILES": "true",
     "com.intellij.ml.llm.matterhorn.ej.ui.settings.DefaultAutoModeForALLUsers.v1": "true",
     "com.intellij.ml.llm.matterhorn.ej.ui.settings.DefaultModelSelectionForGA.v1": "true",
+    "datagrid.heatmap.switchedByDefault": "false",
     "django.template.preview.state": "SHOW_EDITOR",
-    "git-widget-placeholder": "Battles",
+    "git-widget-placeholder": "Refresh",
     "junie.onboarding.icon.badge.shown": "true",
     "last_opened_file_path": "C:/Users/edbou/Documents/Code/clashstats_v2",
     "node.js.detected.package.eslint": "true",

--- a/clashstats/urls.py
+++ b/clashstats/urls.py
@@ -7,5 +7,6 @@ urlpatterns = [
     path('api/v1/clan/search', views.searchClan, name='SearchClan'),
     path('api/v1/members', views.addMembers, name='addMember'),
     path('api/v1/clan', views.addClan, name='addClan'),
-    path('api/v1/battlelog', views.addBattleLog, name='addBattleLog')
+    path('api/v1/battlelog', views.addBattleLog, name='addBattleLog'),
+    path('api/v1/refreshclan', views.refreshClan, name='refreshClan')
 ]


### PR DESCRIPTION
---

### Description

This pull request introduces the following changes:

- Adds a new `refreshClan` endpoint to support clan data updates.
- Improves clan and member update logic using `update_or_create` for better efficiency and clarity.