### PR TITLE
Remove unused fields from `BattleLogs` model

### DIFF
--- a/clashstats/battlelog.py
+++ b/clashstats/battlelog.py
@@ -36,9 +36,7 @@ def createbattlelog(playertag, url, headers):
                 if not BattleLogs.objects.filter(id=winlose["hash"]).exists():
                     BattleLogs.objects.create(
                         id=winlose["hash"],
-                        type=battle["type"],
                         battleTime=battle["battleTime"],
-                        gameMode=battle["gameMode"]["name"],
                         winner1=Members.objects.get(tag=winlose["winner1"]),
                         winner2=Members.objects.get(tag=winlose["winner2"]),
                         loser1=Members.objects.get(tag=winlose["loser1"]),

--- a/clashstats/models.py
+++ b/clashstats/models.py
@@ -33,9 +33,7 @@ class Members(models.Model):
 
 class BattleLogs(models.Model):
     id = models.CharField(primary_key=True, editable=False)
-    type = models.CharField(max_length=50)
     battleTime = models.DateTimeField()
-    gameMode = models.CharField(max_length=25)
     winner1 = models.ForeignKey(
         Members, on_delete=models.CASCADE, null=False, related_name="winner12member"
     )


### PR DESCRIPTION
### Description

This pull request removes the `type` and `gameMode` fields from the `BattleLogs` model, along with any related logic. These fields are no longer in use and have been cleaned up to simplify the model.