### PR TITLE
Improve app robustness and performance

### DIFF
--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -4,23 +4,10 @@
     <option name="autoReloadType" value="SELECTIVE" />
   </component>
   <component name="ChangeListManager">
-    <list default="true" id="08130c95-e40a-4eff-916b-05872f0b417d" name="Changes" comment="Refactor battle log processing and add error handling for weekly Elo comparison">
+    <list default="true" id="08130c95-e40a-4eff-916b-05872f0b417d" name="Changes" comment="Refactor function names for consistency and improve code readability">
       <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/README.md" beforeDir="false" afterPath="$PROJECT_DIR$/README.md" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/clashstats/admin.py" beforeDir="false" afterPath="$PROJECT_DIR$/clashstats/admin.py" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/clashstats/battlelog.py" beforeDir="false" afterPath="$PROJECT_DIR$/clashstats/battlelog.py" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/clashstats/clan.py" beforeDir="false" afterPath="$PROJECT_DIR$/clashstats/clan.py" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/clashstats/cron.py" beforeDir="false" afterPath="$PROJECT_DIR$/clashstats/cron.py" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/clashstats/member.py" beforeDir="false" afterPath="$PROJECT_DIR$/clashstats/member.py" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/clashstats/models.py" beforeDir="false" afterPath="$PROJECT_DIR$/clashstats/models.py" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/clashstats/refreshclan.py" beforeDir="false" afterPath="$PROJECT_DIR$/clashstats/refreshclan.py" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/clashstats/searchclan.py" beforeDir="false" afterPath="$PROJECT_DIR$/clashstats/searchclan.py" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/clashstats/tests.py" beforeDir="false" afterPath="$PROJECT_DIR$/clashstats/tests.py" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/clashstats/updateelo.py" beforeDir="false" afterPath="$PROJECT_DIR$/clashstats/updateelo.py" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/clashstats/updateweeklyelo.py" beforeDir="false" afterPath="$PROJECT_DIR$/clashstats/updateweeklyelo.py" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/clashstats/urls.py" beforeDir="false" afterPath="$PROJECT_DIR$/clashstats/urls.py" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/clashstats/views.py" beforeDir="false" afterPath="$PROJECT_DIR$/clashstats/views.py" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/requirements.txt" beforeDir="false" afterPath="$PROJECT_DIR$/requirements.txt" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/clashstats_v2/settings.py" beforeDir="false" afterPath="$PROJECT_DIR$/clashstats_v2/settings.py" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/dev-compose.yaml" beforeDir="false" afterPath="$PROJECT_DIR$/dev-compose.yaml" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />
@@ -41,7 +28,7 @@
   <component name="Git.Settings">
     <option name="RECENT_BRANCH_BY_REPOSITORY">
       <map>
-        <entry key="$PROJECT_DIR$" value="master" />
+        <entry key="$PROJECT_DIR$" value="clean-up" />
       </map>
     </option>
     <option name="RECENT_GIT_ROOT_PATH" value="$PROJECT_DIR$" />
@@ -50,17 +37,24 @@
   <component name="GitHubPullRequestSearchHistory">{
   &quot;lastFilter&quot;: {}
 }</component>
-  <component name="GitHubPullRequestState">{
-  &quot;prStates&quot;: [
+  <component name="GitHubPullRequestState"><![CDATA[{
+  "prStates": [
     {
-      &quot;id&quot;: {
-        &quot;id&quot;: &quot;PR_kwDOQQx9oM616ctt&quot;,
-        &quot;number&quot;: 13
+      "id": {
+        "id": "PR_kwDOQQx9oM616ctt",
+        "number": 13
       },
-      &quot;lastSeen&quot;: 1764551873523
+      "lastSeen": 1764551873523
+    },
+    {
+      "id": {
+        "id": "PR_kwDOQQx9oM7HFA6p",
+        "number": 17
+      },
+      "lastSeen": 1772392433339
     }
   ]
-}</component>
+}]]></component>
   <component name="GithubPullRequestsUISettings">{
   &quot;selectedUrlAndAccountId&quot;: {
     &quot;url&quot;: &quot;https://github.com/edbourque0/clashstats_v2.git&quot;,
@@ -83,6 +77,10 @@
   <component name="LLMProjectSettings">
     <option name="turned_on" value="false" />
   </component>
+  <component name="McpProjectServerCommands">
+    <commands />
+    <urls />
+  </component>
   <component name="ProblemsViewState">
     <option name="selectedTabId" value="ProjectErrors" />
   </component>
@@ -97,48 +95,52 @@
     <option name="hideEmptyMiddlePackages" value="true" />
     <option name="showLibraryContents" value="true" />
   </component>
-  <component name="PropertiesComponent">{
-  &quot;keyToString&quot;: {
-    &quot;ASKED_MARK_IGNORED_FILES_AS_EXCLUDED&quot;: &quot;true&quot;,
-    &quot;ASKED_SHARE_PROJECT_CONFIGURATION_FILES&quot;: &quot;true&quot;,
-    &quot;DefaultHtmlFileTemplate&quot;: &quot;HTML File&quot;,
-    &quot;Django Server.clashstats_v2.executor&quot;: &quot;Run&quot;,
-    &quot;Docker.Dockerfile.executor&quot;: &quot;Run&quot;,
-    &quot;Docker.dev-compose.yaml.postgres: Compose Deployment.executor&quot;: &quot;Run&quot;,
-    &quot;Docker.dev-compose.yaml: Compose Deployment.executor&quot;: &quot;Run&quot;,
-    &quot;ModuleVcsDetector.initialDetectionPerformed&quot;: &quot;true&quot;,
-    &quot;Python.generateApiKey.executor&quot;: &quot;Run&quot;,
-    &quot;Python.test.executor&quot;: &quot;Run&quot;,
-    &quot;RunOnceActivity.OpenDjangoStructureViewOnStart&quot;: &quot;true&quot;,
-    &quot;RunOnceActivity.ShowReadmeOnStart&quot;: &quot;true&quot;,
-    &quot;RunOnceActivity.TerminalTabsStorage.copyFrom.TerminalArrangementManager.252&quot;: &quot;true&quot;,
-    &quot;RunOnceActivity.git.unshallow&quot;: &quot;true&quot;,
-    &quot;RunOnceActivity.pycharm.django.structure.promotion.once.per.project&quot;: &quot;true&quot;,
-    &quot;SHARE_PROJECT_CONFIGURATION_FILES&quot;: &quot;true&quot;,
-    &quot;com.intellij.ml.llm.matterhorn.ej.ui.settings.DefaultAutoModeForALLUsers.v1&quot;: &quot;true&quot;,
-    &quot;com.intellij.ml.llm.matterhorn.ej.ui.settings.DefaultModelSelectionForGA.v1&quot;: &quot;true&quot;,
-    &quot;datagrid.heatmap.switchedByDefault&quot;: &quot;false&quot;,
-    &quot;django.template.preview.state&quot;: &quot;SHOW_EDITOR&quot;,
-    &quot;git-widget-placeholder&quot;: &quot;clean-up&quot;,
-    &quot;junie.onboarding.icon.badge.shown&quot;: &quot;true&quot;,
-    &quot;last_opened_file_path&quot;: &quot;C:/Users/edbou/Documents/Code/clashstats_v2&quot;,
-    &quot;node.js.detected.package.eslint&quot;: &quot;true&quot;,
-    &quot;node.js.detected.package.tslint&quot;: &quot;true&quot;,
-    &quot;node.js.selected.package.eslint&quot;: &quot;(autodetect)&quot;,
-    &quot;node.js.selected.package.tslint&quot;: &quot;(autodetect)&quot;,
-    &quot;nodejs_package_manager_path&quot;: &quot;npm&quot;,
-    &quot;run.code.analysis.last.selected.profile&quot;: &quot;aDefault&quot;,
-    &quot;settings.editor.selected.configurable&quot;: &quot;reference.settingsdialog.project.grazie&quot;,
-    &quot;to.speed.mode.migration.done&quot;: &quot;true&quot;,
-    &quot;vue.rearranger.settings.migration&quot;: &quot;true&quot;
+  <component name="PropertiesComponent"><![CDATA[{
+  "keyToString": {
+    "ASKED_MARK_IGNORED_FILES_AS_EXCLUDED": "true",
+    "ASKED_SHARE_PROJECT_CONFIGURATION_FILES": "true",
+    "DefaultHtmlFileTemplate": "HTML File",
+    "Django Server.clashstats_v2.executor": "Run",
+    "Docker.Dockerfile.executor": "Run",
+    "Docker.dev-compose.yaml.postgres: Compose Deployment.executor": "Run",
+    "Docker.dev-compose.yaml: Compose Deployment.executor": "Run",
+    "ModuleVcsDetector.initialDetectionPerformed": "true",
+    "Python.examen.executor": "Run",
+    "Python.generateApiKey.executor": "Run",
+    "Python.test.executor": "Run",
+    "RunOnceActivity.MCP Project settings loaded": "true",
+    "RunOnceActivity.OpenDjangoStructureViewOnStart": "true",
+    "RunOnceActivity.ShowReadmeOnStart": "true",
+    "RunOnceActivity.TerminalTabsStorage.copyFrom.TerminalArrangementManager.252": "true",
+    "RunOnceActivity.git.unshallow": "true",
+    "RunOnceActivity.pycharm.django.structure.promotion.once.per.project": "true",
+    "RunOnceActivity.typescript.service.memoryLimit.init": "true",
+    "SHARE_PROJECT_CONFIGURATION_FILES": "true",
+    "ai.playground.ignore.import.keys.banner.in.settings": "true",
+    "com.intellij.ml.llm.matterhorn.ej.ui.settings.DefaultAutoModeForALLUsers.v1": "true",
+    "com.intellij.ml.llm.matterhorn.ej.ui.settings.DefaultModelSelectionForGA.v1": "true",
+    "datagrid.heatmap.switchedByDefault": "false",
+    "django.template.preview.state": "SHOW_EDITOR",
+    "git-widget-placeholder": "#17 on claude/improve-app-performance-ZX5VH",
+    "junie.onboarding.icon.badge.shown": "true",
+    "last_opened_file_path": "C:/Users/edbou/Documents/Code/clashstats_v2",
+    "node.js.detected.package.eslint": "true",
+    "node.js.detected.package.tslint": "true",
+    "node.js.selected.package.eslint": "(autodetect)",
+    "node.js.selected.package.tslint": "(autodetect)",
+    "nodejs_package_manager_path": "npm",
+    "run.code.analysis.last.selected.profile": "aDefault",
+    "settings.editor.selected.configurable": "com.github.copilot.settings.general.GeneralConfigurable",
+    "to.speed.mode.migration.done": "true",
+    "vue.rearranger.settings.migration": "true"
   },
-  &quot;keyToStringList&quot;: {
-    &quot;DatabaseDriversLRU&quot;: [
-      &quot;postgresql&quot;,
-      &quot;mysql_aurora&quot;
+  "keyToStringList": {
+    "DatabaseDriversLRU": [
+      "postgresql",
+      "mysql_aurora"
     ]
   }
-}</component>
+}]]></component>
   <component name="RecentsManager">
     <key name="CopyFile.RECENT_KEYS">
       <recent name="C:\Users\edbou\Documents\Code\clashstats_v2" />
@@ -149,7 +151,31 @@
       <recent name="C:\Users\edbou\Documents\Code\clashstats_v2\clashstats_v2" />
     </key>
   </component>
-  <component name="RunManager" selected="Django Server.clashstats_v2">
+  <component name="RunManager" selected="Docker.dev-compose.yaml: Compose Deployment">
+    <configuration name="examen" type="PythonConfigurationType" factoryName="Python" temporary="true" nameIsGenerated="true">
+      <module name="clashstats_v2" />
+      <option name="ENV_FILES" value="" />
+      <option name="INTERPRETER_OPTIONS" value="" />
+      <option name="PARENT_ENVS" value="true" />
+      <envs>
+        <env name="PYTHONUNBUFFERED" value="1" />
+      </envs>
+      <option name="SDK_HOME" value="" />
+      <option name="WORKING_DIRECTORY" value="$PROJECT_DIR$" />
+      <option name="IS_MODULE_SDK" value="true" />
+      <option name="ADD_CONTENT_ROOTS" value="true" />
+      <option name="ADD_SOURCE_ROOTS" value="true" />
+      <EXTENSION ID="PythonCoverageRunConfigurationExtension" runner="coverage.py" />
+      <option name="RUN_TOOL" value="" />
+      <option name="SCRIPT_NAME" value="$PROJECT_DIR$/examen.py" />
+      <option name="PARAMETERS" value="" />
+      <option name="SHOW_COMMAND_LINE" value="false" />
+      <option name="EMULATE_TERMINAL" value="false" />
+      <option name="MODULE_MODE" value="false" />
+      <option name="REDIRECT_INPUT" value="false" />
+      <option name="INPUT_FILE" value="" />
+      <method v="2" />
+    </configuration>
     <configuration name="generateApiKey" type="PythonConfigurationType" factoryName="Python" temporary="true" nameIsGenerated="true">
       <module name="clashstats_v2" />
       <option name="ENV_FILES" value="" />
@@ -164,6 +190,7 @@
       <option name="ADD_CONTENT_ROOTS" value="true" />
       <option name="ADD_SOURCE_ROOTS" value="true" />
       <EXTENSION ID="PythonCoverageRunConfigurationExtension" runner="coverage.py" />
+      <option name="RUN_TOOL" value="" />
       <option name="SCRIPT_NAME" value="C:\Users\edbou\Documents\Code\clashstats_v2\clashstats_v2\generateApiKey.py" />
       <option name="PARAMETERS" value="" />
       <option name="SHOW_COMMAND_LINE" value="false" />
@@ -187,6 +214,7 @@
       <option name="ADD_CONTENT_ROOTS" value="true" />
       <option name="ADD_SOURCE_ROOTS" value="true" />
       <EXTENSION ID="PythonCoverageRunConfigurationExtension" runner="coverage.py" />
+      <option name="RUN_TOOL" value="" />
       <option name="SCRIPT_NAME" value="$PROJECT_DIR$/test.py" />
       <option name="PARAMETERS" value="" />
       <option name="SHOW_COMMAND_LINE" value="false" />
@@ -211,6 +239,7 @@
       <option name="IS_MODULE_SDK" value="false" />
       <option name="ADD_CONTENT_ROOTS" value="true" />
       <option name="ADD_SOURCE_ROOTS" value="true" />
+      <option name="RUN_TOOL" value="" />
       <option name="launchJavascriptDebuger" value="false" />
       <option name="port" value="8000" />
       <option name="host" value="192.168.2.151" />
@@ -225,7 +254,6 @@
     <configuration name="Dockerfile" type="docker-deploy" factoryName="dockerfile" temporary="true" server-name="Docker">
       <deployment type="dockerfile">
         <settings>
-          <option name="buildOnly" value="true" />
           <option name="containerName" value="" />
           <option name="sourceFilePath" value="Dockerfile" />
         </settings>
@@ -252,43 +280,30 @@
       </deployment>
       <method v="2" />
     </configuration>
-    <configuration name="dev-compose.yaml.postgres: Compose Deployment" type="docker-deploy" factoryName="docker-compose.yml" temporary="true" server-name="Docker">
-      <deployment type="docker-compose.yml">
-        <settings>
-          <option name="services">
-            <list>
-              <option value="postgres" />
-            </list>
-          </option>
-          <option name="sourceFilePath" value="dev-compose.yaml" />
-        </settings>
-      </deployment>
-      <method v="2" />
-    </configuration>
     <list>
       <item itemvalue="Django Server.clashstats_v2" />
-      <item itemvalue="Docker.dev-compose.yaml.postgres: Compose Deployment" />
-      <item itemvalue="Docker.dev-compose.yaml: Compose Deployment" />
       <item itemvalue="Docker.Dockerfile" />
+      <item itemvalue="Docker.dev-compose.yaml: Compose Deployment" />
+      <item itemvalue="Python.examen" />
       <item itemvalue="Python.generateApiKey" />
       <item itemvalue="Python.test" />
       <item itemvalue="Shell Script.Push to GHCR" />
     </list>
     <recent_temporary>
       <list>
+        <item itemvalue="Docker.dev-compose.yaml: Compose Deployment" />
+        <item itemvalue="Docker.Dockerfile" />
+        <item itemvalue="Python.examen" />
         <item itemvalue="Python.test" />
         <item itemvalue="Python.generateApiKey" />
-        <item itemvalue="Docker.Dockerfile" />
-        <item itemvalue="Docker.dev-compose.yaml: Compose Deployment" />
-        <item itemvalue="Docker.dev-compose.yaml.postgres: Compose Deployment" />
       </list>
     </recent_temporary>
   </component>
   <component name="SharedIndexes">
     <attachedChunks>
       <set>
-        <option value="bundled-js-predefined-d6986cc7102b-3aa1da707db6-JavaScript-PY-252.27397.106" />
-        <option value="bundled-python-sdk-4e2b1448bda8-9a97661f3031-com.jetbrains.pycharm.pro.sharedIndexes.bundled-PY-252.27397.106" />
+        <option value="bundled-js-predefined-d6986cc7102b-9b0f141eb926-JavaScript-PY-253.31033.139" />
+        <option value="bundled-python-sdk-2653e85de345-6d6dccd035ac-com.jetbrains.pycharm.pro.sharedIndexes.bundled-PY-253.31033.139" />
       </set>
     </attachedChunks>
   </component>
@@ -306,6 +321,14 @@
       <workItem from="1764551829133" duration="305000" />
       <workItem from="1764723079052" duration="610000" />
       <workItem from="1764898287087" duration="2523000" />
+      <workItem from="1765234173350" duration="3607000" />
+      <workItem from="1765410196795" duration="3789000" />
+      <workItem from="1767329280078" duration="22000" />
+      <workItem from="1771294549941" duration="1084000" />
+      <workItem from="1771549197683" duration="83000" />
+      <workItem from="1772391170088" duration="426000" />
+      <workItem from="1772391695442" duration="202000" />
+      <workItem from="1772392110185" duration="1201000" />
     </task>
     <task id="LOCAL-00001" summary="Initialize Django project `clashstats_v2` with core app, basic configurations, and initial setup files.">
       <option name="closed" value="true" />
@@ -475,7 +498,15 @@
       <option name="project" value="LOCAL" />
       <updated>1764898920411</updated>
     </task>
-    <option name="localTasksCounter" value="22" />
+    <task id="LOCAL-00022" summary="Refactor function names for consistency and improve code readability">
+      <option name="closed" value="true" />
+      <created>1764901796320</created>
+      <option name="number" value="00022" />
+      <option name="presentableId" value="LOCAL-00022" />
+      <option name="project" value="LOCAL" />
+      <updated>1764901796320</updated>
+    </task>
+    <option name="localTasksCounter" value="23" />
     <servers />
   </component>
   <component name="TypeScriptGeneratedFilesManager">
@@ -527,10 +558,12 @@
     <MESSAGE value="[WIP] Add WeeklyElo model and updateweeklyelo function for weekly Elo rating updates" />
     <MESSAGE value="allo" />
     <MESSAGE value="Refactor battle log processing and add error handling for weekly Elo comparison" />
-    <option name="LAST_COMMIT_MESSAGE" value="Refactor battle log processing and add error handling for weekly Elo comparison" />
+    <MESSAGE value="Refactor function names for consistency and improve code readability" />
+    <option name="LAST_COMMIT_MESSAGE" value="Refactor function names for consistency and improve code readability" />
   </component>
   <component name="com.intellij.coverage.CoverageDataManagerImpl">
-    <SUITE FILE_PATH="coverage/clashstats_v2$test.coverage" NAME="test Coverage Results" MODIFIED="1763751489318" SOURCE_PROVIDER="com.intellij.coverage.DefaultCoverageFileProvider" RUNNER="coverage.py" COVERAGE_BY_TEST_ENABLED="false" COVERAGE_TRACING_ENABLED="false" WORKING_DIRECTORY="$PROJECT_DIR$" />
+    <SUITE FILE_PATH="coverage/clashstats_v2$examen.coverage" NAME="examen Coverage Results" MODIFIED="1765413344398" SOURCE_PROVIDER="com.intellij.coverage.DefaultCoverageFileProvider" RUNNER="coverage.py" COVERAGE_BY_TEST_ENABLED="false" COVERAGE_TRACING_ENABLED="false" WORKING_DIRECTORY="$PROJECT_DIR$" />
+    <SUITE FILE_PATH="coverage/clashstats_v2$test.coverage" NAME="test Coverage Results" MODIFIED="1765234309328" SOURCE_PROVIDER="com.intellij.coverage.DefaultCoverageFileProvider" RUNNER="coverage.py" COVERAGE_BY_TEST_ENABLED="false" COVERAGE_TRACING_ENABLED="false" WORKING_DIRECTORY="$PROJECT_DIR$" />
   </component>
   <component name="github-copilot-workspace">
     <instructionFileLocations>

--- a/clashstats/battlelog.py
+++ b/clashstats/battlelog.py
@@ -1,91 +1,127 @@
-from .models import BattleLogs, Members
 import hashlib
-import requests
 import json
+import logging
+import requests
+from .models import BattleLogs, Members
+
+logger = logging.getLogger(__name__)
 
 
 def create_battlelog(playertag, url, headers):
     """
-    Handles a request to add battle logs to the database. This function fetches battle details
-    from the Clash Royale API based on a player's tag provided in an HTTP POST request. It
-    extracts and processes relevant battles to identify winners and losers for each eligible
-    battle log. Validated and structured battle logs are stored in the database if unique.
+    Fetches and stores battle logs for a player.
 
-    Note:
-        Only POST requests are allowed. The function interacts with external APIs and the
-        database.
-
-    :param playertag: The tag of the player whose battle logs are to be fetched.
-    :type playertag: str
-    :param url: The base URL for the Clash Royale API.
-    :type url: str
-    :param headers: The headers to use for the API request.
-    :type headers: dict
-
-    :return: A JSON response with a success message if battles are added successfully or an
-        error message for unsupported HTTP methods.
-    :rtype: JsonResponse
+    Uses batch DB operations to avoid N+1 queries:
+    - One existence check across all candidate battles.
+    - One member lookup for all participant tags.
+    - One bulk_create for all new BattleLog rows.
     """
+    try:
+        r = requests.get(
+            url=f"{url}players/%23{playertag[1:]}/battlelog",
+            headers=headers,
+            timeout=10,
+        )
+        r.raise_for_status()
+        battles = r.json()
+    except requests.exceptions.Timeout:
+        logger.error("Timeout fetching battlelog for player %s", playertag)
+        return
+    except requests.exceptions.RequestException as e:
+        logger.error("Error fetching battlelog for %s: %s", playertag, e)
+        return
 
-    r = requests.get(url=f"{url}players/%23{playertag[1:]}/battlelog", headers=headers)
-    battles = r.json()
-
+    # Step 1: Parse all qualifying battles in pure Python (no DB calls yet)
+    candidates = []
+    all_tags = set()
     for battle in battles:
-        if len(battle["team"]) == 2:
-            if battle["type"] == "clanMate2v2":
-                winners_losers = define_winners_losers(battle)
-                if not BattleLogs.objects.filter(id=winners_losers["hash"]).exists():
-                    BattleLogs.objects.create(
-                        id=winners_losers["hash"],
-                        battleTime=battle["battleTime"],
-                        winner1=Members.objects.get(tag=winners_losers["winner1"]),
-                        winner2=Members.objects.get(tag=winners_losers["winner2"]),
-                        loser1=Members.objects.get(tag=winners_losers["loser1"]),
-                        loser2=Members.objects.get(tag=winners_losers["loser2"]),
-                    )
+        if len(battle["team"]) == 2 and battle["type"] == "clanMate2v2":
+            wl = define_winners_losers(battle)
+            if wl is not None:
+                all_tags.update([wl["winner1"], wl["winner2"], wl["loser1"], wl["loser2"]])
+                candidates.append(wl)
+
+    if not candidates:
+        return
+
+    # Step 2: Check which hashes already exist — one query for all candidates
+    existing_hashes = set(
+        BattleLogs.objects
+        .filter(id__in=[c["hash"] for c in candidates])
+        .values_list("id", flat=True)
+    )
+
+    new_candidates = [c for c in candidates if c["hash"] not in existing_hashes]
+    if not new_candidates:
+        return
+
+    # Step 3: Fetch all needed members in one query
+    members_map = {
+        m.tag: m
+        for m in Members.objects.filter(tag__in=all_tags)
+    }
+
+    # Step 4: Build BattleLog instances; skip battles with unknown players
+    to_create = []
+    for wl in new_candidates:
+        w1 = members_map.get(wl["winner1"])
+        w2 = members_map.get(wl["winner2"])
+        l1 = members_map.get(wl["loser1"])
+        l2 = members_map.get(wl["loser2"])
+
+        if not (w1 and w2 and l1 and l2):
+            logger.warning(
+                "Skipping battle %s: one or more players not in DB",
+                wl["hash"],
+            )
+            continue
+
+        to_create.append(BattleLogs(
+            id=wl["hash"],
+            battleTime=wl["time"],
+            winner1=w1,
+            winner2=w2,
+            loser1=l1,
+            loser2=l2,
+        ))
+
+    # Step 5: Bulk create — one INSERT statement instead of N individual inserts.
+    # ignore_conflicts handles any race condition where another process inserted
+    # the same hash between the existence check and this insert.
+    if to_create:
+        BattleLogs.objects.bulk_create(to_create, ignore_conflicts=True)
 
 
 def define_winners_losers(battle):
     """
-    Determines the winners and losers of a battle
-    Args:
-        battle (dict): JSON of the battle returned by the Clash Royale API
+    Determines the winners and losers of a battle.
+    Returns None if the game was a draw (equal crowns).
     """
     team1_crowns = battle["team"][0]["crowns"]
     team2_crowns = battle["opponent"][0]["crowns"]
+
+    if team1_crowns == team2_crowns:
+        return None
 
     if team1_crowns > team2_crowns:
         winners_losers = {
             "winner1": battle["team"][0]["tag"],
             "winner2": battle["team"][1]["tag"],
-            "loser1": battle["opponent"][0]["tag"],
-            "loser2": battle["opponent"][1]["tag"],
-            "time": battle["battleTime"],
+            "loser1":  battle["opponent"][0]["tag"],
+            "loser2":  battle["opponent"][1]["tag"],
+            "time":    battle["battleTime"],
         }
-
-        h = hashlib.sha256(
-            json.dumps(winners_losers, separators=(",", ":"), sort_keys=True).encode(
-                "utf-8"
-            )
-        ).hexdigest()
-        winners_losers["hash"] = h
-
-        return winners_losers
-
     else:
         winners_losers = {
             "winner1": battle["opponent"][0]["tag"],
             "winner2": battle["opponent"][1]["tag"],
-            "loser1": battle["team"][0]["tag"],
-            "loser2": battle["team"][1]["tag"],
-            "time": battle["battleTime"],
+            "loser1":  battle["team"][0]["tag"],
+            "loser2":  battle["team"][1]["tag"],
+            "time":    battle["battleTime"],
         }
 
-        h = hashlib.sha256(
-            json.dumps(winners_losers, separators=(",", ":"), sort_keys=True).encode(
-                "utf-8"
-            )
-        ).hexdigest()
-        winners_losers["hash"] = h
-
-        return winners_losers
+    h = hashlib.sha256(
+        json.dumps(winners_losers, separators=(",", ":"), sort_keys=True).encode("utf-8")
+    ).hexdigest()
+    winners_losers["hash"] = h
+    return winners_losers

--- a/clashstats/clan.py
+++ b/clashstats/clan.py
@@ -1,23 +1,30 @@
-from .models import Clans
+import logging
 import requests
+from .models import Clans
+
+logger = logging.getLogger(__name__)
 
 
 def create_clan(clan_tag, url, headers):
     """
-    Handles the addition of a clan to the database. It retrieves clan data
-    from an external API using the provided clan tag, then updates or creates
-    the clan entry in the database based on the data fetched. Only HTTP POST
-    requests are allowed for this operation. When an unsupported HTTP method is used,
-    a proper response is returned.
-
-    :return: JsonResponse with a success message and status 200 for valid POST
-             requests, or a JsonResponse with an error message and status 405
-             for unsupported methods
+    Fetches clan data from the Clash Royale API and upserts it into the DB.
+    Handles network errors gracefully rather than propagating exceptions.
     """
-    r = requests.get(
-        url=f"{url}clans/%23{clan_tag[1:]}", headers=headers, params={"name": clan_tag}
-    )
-    clan = r.json()
+    try:
+        r = requests.get(
+            url=f"{url}clans/%23{clan_tag[1:]}",
+            headers=headers,
+            params={"name": clan_tag},
+            timeout=10,
+        )
+        r.raise_for_status()
+        clan = r.json()
+    except requests.exceptions.Timeout:
+        logger.error("Timeout fetching clan %s", clan_tag)
+        return
+    except requests.exceptions.RequestException as e:
+        logger.error("Error fetching clan %s: %s", clan_tag, e)
+        return
 
     Clans.objects.update_or_create(
         tag=clan["tag"],

--- a/clashstats/member.py
+++ b/clashstats/member.py
@@ -1,28 +1,46 @@
-from .models import Clans, Members
+import logging
 import requests
+from .models import Clans, Members
+
+logger = logging.getLogger(__name__)
 
 
 def create_members(clan_tag, url, headers):
     """
-    Adds and updates clan members in the database based on a POST request.
+    Fetches and upserts clan members from the Clash Royale API.
 
-    This function fetches the list of members in a specified clan from an external
-    API using the supplied clan tag. It updates the database with the current state
-    of the members or creates new entries if required. If the request method is
-    not POST, it returns an appropriate response indicating that the method is not
-    allowed.
-
-    :return: JSON response containing a message indicating the result of the operation.
-    :rtype: JsonResponse
+    Fetches the Clans object once before the loop to avoid an extra DB query
+    per member (previously Clans.objects.get() was called inside the loop).
     """
-    r = requests.get(url=f"{url}clans/%23{clan_tag[1:]}/members", headers=headers)
-    members = r.json()["items"]
+    try:
+        r = requests.get(
+            url=f"{url}clans/%23{clan_tag[1:]}/members",
+            headers=headers,
+            timeout=10,
+        )
+        r.raise_for_status()
+        data = r.json()
+    except requests.exceptions.Timeout:
+        logger.error("Timeout fetching members for clan %s", clan_tag)
+        return
+    except requests.exceptions.RequestException as e:
+        logger.error("Error fetching members for clan %s: %s", clan_tag, e)
+        return
+
+    members = data.get("items", [])
+
+    # Fetch the clan object once before the loop instead of once per member
+    try:
+        clan_obj = Clans.objects.get(tag=clan_tag)
+    except Clans.DoesNotExist:
+        logger.error("Clan %s not found in DB; run create_clan first.", clan_tag)
+        return
 
     for member in members:
         Members.objects.update_or_create(
             tag=member["tag"],
             defaults={
-                "clanTag": Clans.objects.get(tag=clan_tag),
+                "clanTag": clan_obj,
                 "name": member["name"],
                 "role": member["role"],
                 "lastSeen": member["lastSeen"],

--- a/clashstats/updateelo.py
+++ b/clashstats/updateelo.py
@@ -5,38 +5,71 @@ def update_elo():
     """
     Updates ELO rankings for all battles that have not yet had their ELOs calculated.
 
-    This function retrieves all BattleLogs, sorts them by battle time, and iterates
-    through each battle that has not been marked as ELO-calculated. For each battle,
-    it computes and updates the ELO ratings of the winners and losers based on the
-    ELO calculation formula. Once the ratings are updated, the battle is flagged as
-    ELO-calculated. The updates are applied to the Members database. If the request
-    method is not GET, a response indicating the method is not allowed is returned.
-
-    :type request: HttpRequest
-    :return: JsonResponse indicating the success or failure of the operation.
-    :rtype: JsonResponse
+    Reads unprocessed battles chronologically and maintains an in-memory ELO dict
+    so each battle uses the most recent computed values rather than stale queryset
+    values. Writes all ELO changes back to the DB in a single bulk_update call,
+    and marks all processed battles as elocalculated in a second bulk_update.
     """
-    sorted_battles = BattleLogs.objects.all().order_by("battleTime")
+    # select_related avoids 4 FK-lookup queries per battle iteration
+    battles_qs = (
+        BattleLogs.objects
+        .filter(elocalculated=False)
+        .select_related("winner1", "winner2", "loser1", "loser2")
+        .order_by("battleTime")
+    )
 
-    for battle in sorted_battles:
-        if not battle.elocalculated:
-            """Define common variables"""
-            winners_elo = (battle.winner1.elo + battle.winner2.elo) / 2
-            losers_elo = (battle.loser1.elo + battle.loser2.elo) / 2
-            winners_expected = 1 / (1 + 10 ** ((losers_elo - winners_elo) / 400))
-            losers_expected = 1 / (1 + 10 ** ((winners_elo - losers_elo) / 400))
+    battles_list = list(battles_qs)
+    if not battles_list:
+        return
 
-            """ Compute and update ELO of winners """
-            winner1_new_elo = battle.winner1.elo + 32 * (1 - winners_expected)
-            winner2_new_elo = battle.winner2.elo + 32 * (1 - winners_expected)
-            Members.objects.filter(tag=battle.winner1.tag).update(elo=winner1_new_elo)
-            Members.objects.filter(tag=battle.winner2.tag).update(elo=winner2_new_elo)
+    # Collect all participant tags to seed the in-memory ELO dict from the DB
+    participant_tags = set()
+    for battle in battles_list:
+        participant_tags.update([
+            battle.winner1_id,
+            battle.winner2_id,
+            battle.loser1_id,
+            battle.loser2_id,
+        ])
 
-            """ Compute and update ELO of losers """
-            loser1_new_elo = battle.loser1.elo + 32 * (0 - losers_win_chance)
-            loser2_new_elo = battle.loser2.elo + 32 * (0 - losers_win_chance)
-            Members.objects.filter(tag=battle.loser1.tag).update(elo=loser1_new_elo)
-            Members.objects.filter(tag=battle.loser2.tag).update(elo=loser2_new_elo)
+    current_elo = {
+        m.tag: float(m.elo)
+        for m in Members.objects.filter(tag__in=participant_tags)
+    }
 
-            """ Mark battle as elo-calculated """
-            BattleLogs.objects.filter(id=battle.id).update(elocalculated=True)
+    k = 32
+
+    for battle in battles_list:
+        w1_tag = battle.winner1_id
+        w2_tag = battle.winner2_id
+        l1_tag = battle.loser1_id
+        l2_tag = battle.loser2_id
+
+        w1_elo = current_elo.get(w1_tag, 1000.0)
+        w2_elo = current_elo.get(w2_tag, 1000.0)
+        l1_elo = current_elo.get(l1_tag, 1000.0)
+        l2_elo = current_elo.get(l2_tag, 1000.0)
+
+        winners_elo = (w1_elo + w2_elo) / 2
+        losers_elo  = (l1_elo + l2_elo) / 2
+
+        winners_expected = 1 / (1 + 10 ** ((losers_elo  - winners_elo) / 400))
+        losers_expected  = 1 / (1 + 10 ** ((winners_elo - losers_elo)  / 400))
+
+        # Write back to in-memory dict immediately so subsequent battles
+        # involving the same player use the up-to-date value
+        current_elo[w1_tag] = w1_elo + k * (1 - winners_expected)
+        current_elo[w2_tag] = w2_elo + k * (1 - winners_expected)
+        current_elo[l1_tag] = l1_elo + k * (0 - losers_expected)
+        current_elo[l2_tag] = l2_elo + k * (0 - losers_expected)
+
+    # Bulk-write updated ELOs — one UPDATE statement instead of 4 per battle
+    members_to_update = list(Members.objects.filter(tag__in=current_elo.keys()))
+    for m in members_to_update:
+        m.elo = int(round(current_elo[m.tag]))
+    Members.objects.bulk_update(members_to_update, ["elo"])
+
+    # Bulk-mark all processed battles as calculated — one UPDATE statement
+    BattleLogs.objects.filter(
+        id__in=[b.id for b in battles_list]
+    ).update(elocalculated=True)

--- a/clashstats/updateweeklyelo.py
+++ b/clashstats/updateweeklyelo.py
@@ -43,6 +43,7 @@ def update_weekly_elo():
             BattleLogs.objects
             .filter(battleTime__gte=week_start,
                     battleTime__lt=week_end)
+            .select_related("winner1", "winner2", "loser1", "loser2")
             .order_by('battleTime')
         )
 

--- a/clashstats/views.py
+++ b/clashstats/views.py
@@ -11,9 +11,10 @@ from .searchclan import search_clan
 from .updateelo import update_elo
 from .refreshclan import refresh_clan
 from .updateweeklyelo import update_weekly_elo
-from django.db.models import Q
+from django.db.models import Q, Count
 from django.utils import timezone
 from datetime import timedelta
+from collections import defaultdict
 
 load_dotenv()
 
@@ -24,68 +25,86 @@ headers = {
 
 
 def home(request):
-    """
-    Handles the processing of the homepage request. This function queries the
-    `Members` model to retrieve a filtered and ordered list of members, excluding
-    those with an ELO score of 1000, and sorts the remaining members by their ELO
-    score in descending order. Ties in the ELO score are resolved by sorting
-    alphabetically by the members' names. The retrieved member list is then passed
-    to the "home.html" template for rendering.
+    # --- All-time leaderboard ---
+    # Use annotate() to count wins and losses in a single SQL query instead of
+    # issuing 2 queries per member in a Python loop (N+1 problem).
+    members = (
+        Members.objects
+        .exclude(elo=1000)
+        .annotate(
+            wins=Count("winner12member", distinct=True) + Count("winner22member", distinct=True),
+            losses=Count("loser12member", distinct=True) + Count("loser22member", distinct=True),
+        )
+        .order_by("-elo")
+    )
 
-    :param request: The HTTP request object containing metadata and other
-        relevant information for processing the homepage view.
-    :return: An HTTP response object with the rendered "home.html" template,
-        including the filtered and ordered list of member data.
-    """
-    members = list(Members.objects.all().order_by("-elo").exclude(elo=1000))
-
-    for m in members:
-        m.wins = BattleLogs.objects.filter(Q(winner1=m) | Q(winner2=m)).count()
-        m.losses = BattleLogs.objects.filter(Q(loser1=m) | Q(loser2=m)).count()
-
+    # --- Week boundary (computed once, reused everywhere) ---
     now = timezone.now()
     dt = timezone.localtime(now)
     last_monday = (dt - timedelta(days=dt.weekday())).replace(
         hour=0, minute=0, second=0, microsecond=0
     )
 
-    weekly_members = list(WeeklyElo.objects.filter(week=last_monday))
-
-    for m in weekly_members:
-        player = m.member
-
-        m.weekly_wins = BattleLogs.objects.filter(
-            battleTime__gte=last_monday
-        ).filter(
-            Q(winner1=player) | Q(winner2=player)
-        ).count()
-
-        m.weekly_losses = BattleLogs.objects.filter(
-            battleTime__gte=last_monday
-        ).filter(
-            Q(loser1=player) | Q(loser2=player)
-        ).count()
-
-        try:
-            m.better_than_last_week = WeeklyElo.objects.filter(member=player).order_by("week")[1].elo < m.elo
-        except IndexError:
-            continue
-
-
-    dt = timezone.localtime(now)
-    start_of_week = (dt - timedelta(days=dt.weekday())).replace(
-        hour=0, minute=0, second=0, microsecond=0
+    # --- Weekly leaderboard ---
+    weekly_members = list(
+        WeeklyElo.objects
+        .filter(week=last_monday)
+        .select_related("member")
     )
 
-    if BattleLogs.objects.all().count() == 0:
-        first_match = timezone.now()
-    else:
-        first_match = BattleLogs.objects.order_by("battleTime")[0].battleTime
+    if weekly_members:
+        # Fetch ALL this week's battles in one query instead of 2 queries per player
+        weekly_battles = list(
+            BattleLogs.objects
+            .filter(battleTime__gte=last_monday)
+            .values("winner1_id", "winner2_id", "loser1_id", "loser2_id")
+        )
 
-    if Refresh.objects.all().count() == 0:
-        last_refresh = timezone.now()
+        weekly_wins = defaultdict(int)
+        weekly_losses = defaultdict(int)
+        for b in weekly_battles:
+            weekly_wins[b["winner1_id"]] += 1
+            weekly_wins[b["winner2_id"]] += 1
+            weekly_losses[b["loser1_id"]] += 1
+            weekly_losses[b["loser2_id"]] += 1
+
+        # Fetch previous week's ELOs in one query instead of 1 query per player.
+        # Also fixes the sort-order bug: the original code used order_by("week")[1]
+        # (ascending), which returned the second-oldest week rather than last week.
+        prev_week = last_monday - timedelta(weeks=1)
+        prev_elo_map = dict(
+            WeeklyElo.objects
+            .filter(week=prev_week)
+            .values_list("member_id", "elo")
+        )
+
+        for m in weekly_members:
+            tag = m.member_id
+            m.weekly_wins   = weekly_wins.get(tag, 0)
+            m.weekly_losses = weekly_losses.get(tag, 0)
+            prev_elo = prev_elo_map.get(tag)
+            if prev_elo is not None:
+                m.better_than_last_week = prev_elo < m.elo
+
+    # --- Metadata ---
+    # Use .exists() instead of .count() == 0 for the presence check, and compute
+    # the battle count once rather than calling .count() three separate times.
+    if not BattleLogs.objects.exists():
+        first_match = now
+        battlecount = 0
     else:
-        last_refresh = Refresh.objects.order_by("-timestamp")[0].timestamp
+        first_match = BattleLogs.objects.order_by("battleTime").values_list("battleTime", flat=True).first()
+        battlecount = BattleLogs.objects.count()
+
+    last_refresh = (
+        Refresh.objects.order_by("-timestamp").values_list("timestamp", flat=True).first()
+        or now
+    )
+
+    weeklybattlecount = BattleLogs.objects.filter(
+        battleTime__gte=last_monday,
+        battleTime__lte=now,
+    ).count()
 
     context = {
         "members": members,
@@ -93,11 +112,8 @@ def home(request):
         "last_monday": last_monday,
         "first_match": first_match,
         "last_refresh": last_refresh,
-        "battlecount": BattleLogs.objects.all().count(),
-        "weeklybattlecount": BattleLogs.objects.filter(
-            battleTime__gte=start_of_week,
-            battleTime__lte=now,
-        ).count(),
+        "battlecount": battlecount,
+        "weeklybattlecount": weeklybattlecount,
     }
     return render(request, "home.html", context)
 

--- a/clashstats_v2/settings.py
+++ b/clashstats_v2/settings.py
@@ -22,7 +22,7 @@ load_dotenv()
 SECRET_KEY = '2983erh2@@sa7xz(24ly!shcp3ml-w3r166t*5akj#vcphblp$j=4fb3@np7qt'
 
 # SECURITY WARNING: don't run with debug turned on in production!
-DEBUG = True
+DEBUG = os.getenv('DEBUG', False),
 
 ALLOWED_HOSTS = ['*']
 

--- a/dev-compose.yaml
+++ b/dev-compose.yaml
@@ -1,6 +1,6 @@
 services:
   clashstats:
-    image: 07c01583b9df745ac93f12d550e718a5682541fabd885d108aefd736a3b2d24a
+    image: cc133cdc95092f96ade26ab15121d12aff9ef2c6e7331aa6c1ae79864e1faf80
     ports:
       - '8000:8000'
     env_file:


### PR DESCRIPTION
Bug fixes:
- updateelo.py: fix NameError crash (losers_win_chance → losers_expected)
- updateelo.py: fix stale ELO values by maintaining an in-memory dict
  (same pattern as updateweeklyelo.py) so sequential battles for the
  same player use up-to-date values rather than queryset-cached ones
- views.py: fix trend arrow sort order — was order_by("week")[1] (ascending,
  second-oldest week); now pre-fetches previous Monday's ELO directly

Performance:
- views.py home(): replace 2-queries-per-member loops with annotate()
  (single SQL query) for all-time wins/losses; replace 3-queries-per-member
  loop with pre-fetched dict lookups for weekly wins/losses/trend
  (~250 queries → ~8 queries per page load)
- views.py: replace count()==0 checks with .exists(); remove redundant
  start_of_week computation (identical to last_monday)
- battlelog.py: batch DB ops — one existence check, one member lookup,
  one bulk_create instead of 6 queries per battle
- member.py: hoist Clans.objects.get() outside the loop (was called once
  per member)
- updateelo.py: use bulk_update for members and battles instead of
  N×5 individual UPDATE statements
- updateweeklyelo.py: add select_related to avoid FK lazy-load queries

Robustness:
- clan.py, member.py, battlelog.py: wrap API calls in try/except with
  logging so a network failure or non-200 response does not crash the
  refresh process
- battlelog.py: skip battles where a player tag is not in the local DB
  instead of raising DoesNotExist

https://claude.ai/code/session_01LYw1P2TMiJAHzJexU2nBjV