### PR TITLE
Fix naive datetime warning in WeeklyElo.week field

### DIFF
--- a/clashstats/models.py
+++ b/clashstats/models.py
@@ -59,7 +59,7 @@ class Refresh(models.Model):
 class WeeklyElo(models.Model):
     id = models.UUIDField(primary_key=True, null=False, default=uuid.uuid4)
     member = models.ForeignKey(Members, on_delete=models.CASCADE, related_name="elo_history")
-    week = models.DateTimeField()
+    week = models.DateField()
     elo = models.PositiveIntegerField()
 
     class Meta:

--- a/clashstats/views.py
+++ b/clashstats/views.py
@@ -48,7 +48,7 @@ def home(request):
     # --- Weekly leaderboard ---
     weekly_members = list(
         WeeklyElo.objects
-        .filter(week=last_monday)
+        .filter(week=last_monday.date())
         .select_related("member")
     )
 
@@ -74,7 +74,7 @@ def home(request):
         prev_week = last_monday - timedelta(weeks=1)
         prev_elo_map = dict(
             WeeklyElo.objects
-            .filter(week=prev_week)
+            .filter(week=prev_week.date())
             .values_list("member_id", "elo")
         )
 


### PR DESCRIPTION
WeeklyElo.week was a DateTimeField but always received a plain date object, causing Django to produce a RuntimeWarning about naive datetimes when USE_TZ=True. Changed the field to DateField (matching the actual data) and updated the two filter() calls in views.py to pass .date() instead of a timezone-aware datetime.